### PR TITLE
Loads typekit before html

### DIFF
--- a/app/views/layouts/application.slim
+++ b/app/views/layouts/application.slim
@@ -8,6 +8,9 @@ html
     = stylesheet_link_tag :application, media: 'all'
     = csrf_meta_tags
 
+    script src="//use.typekit.net/rnu4cas.js"
+    script try{Typekit.load();}catch(e){}
+
   body.TopBarLayout ng-app='council' md-theme='council'
     md-toolbar.md-whiteframe-z1.TopBarLayout-topBar
       .md-toolbar-tools
@@ -20,5 +23,3 @@ html
       = yield
     = javascript_include_tag :application
 
-    script src="//use.typekit.net/rnu4cas.js"
-    script try{Typekit.load();}catch(e){}


### PR DESCRIPTION
I believe it's better to make the first load slower (after the first time it
stays in cache) that making the page shake every single time I open th app.
