### PR TITLE
Removes authors array from discussion

### DIFF
--- a/app/assets/javascripts/app/core/models/user.js
+++ b/app/assets/javascripts/app/core/models/user.js
@@ -1,0 +1,16 @@
+(function() {
+  'use strict';
+
+  angular
+    .module('council.core')
+    .factory('User', User);
+
+  function User(DS, $http) {
+    var User = DS.defineResource({
+      name: 'user',
+      endpoint: 'users'
+    });
+
+    return User;
+  }
+})();

--- a/app/assets/javascripts/app/discussions/discussion.js
+++ b/app/assets/javascripts/app/discussions/discussion.js
@@ -5,7 +5,7 @@
     .module('council.discussions')
     .controller('DiscussionCtrl', DiscussionCtrl);
 
-  function DiscussionCtrl(Discussion, discussionId, _, DS) {
+  function DiscussionCtrl(Discussion, User, discussionId, _, DS) {
     var ctrl = this;
 
     ctrl.pageReady = false;
@@ -22,7 +22,10 @@
 
       function addDiscussionData(comment) {
         comment.discussionId = discussion.id;
-        comment.author = _(discussion.authors).findWhere({ id: comment.author_id });
+
+        User.find(comment.author_id).then(function(user) {
+          comment.author = user;
+        });
       }
     }
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,10 @@
 class UsersController < ApplicationController
   authorize_resource
 
+  def show
+    render json: User.find(params[:id])
+  end
+
   def edit
     @user = User.find(params[:id])
   end

--- a/app/serializers/discussion_serializer.rb
+++ b/app/serializers/discussion_serializer.rb
@@ -1,13 +1,6 @@
 class DiscussionSerializer < EditableSerializer
-  attributes :id, :title, :subtitle, :body, :open, :authors, :comments_count
+  attributes :id, :title, :subtitle, :body, :open, :comments_count
 
   has_one :author, embed: :ids
   has_many :comments, embed: :objects
-
-  def authors
-    ActiveModel::ArraySerializer.new(
-      User.find([object.author_id] + object.comments.map(&:author_id).uniq).sort_by(&:id),
-      each_serializer: UserSerializer
-    ).serializable_object
-  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
       end
       resources :notifications, only: [:index, :destroy]
       resources :members, only: [:index]
+      resources :users, only: [:show]
     end
   end
 


### PR DESCRIPTION
I believe it doesn't make sense to send an array of users in the discussion.
If you have a User model the data gets cached and can be used in different
places. If the application evolves having another data structure like
Discussion that needs users you would have two places where you'll send a list
of users.
