### PR TITLE
Removes u-fullSize class

### DIFF
--- a/app/assets/javascripts/app/components/comment_form/templates/comment_form.html.slim
+++ b/app/assets/javascripts/app/components/comment_form/templates/comment_form.html.slim
@@ -9,5 +9,5 @@
           | Add Comment
 
 .TopBarLayout-content
-  md-content.Page.Page--white.md-padding.u-fullSize
+  md-content.Page.Page--white.md-padding
     textarea ng-model="comment.body" label="Comment Here"

--- a/app/assets/javascripts/app/discussions/discussions.module.js
+++ b/app/assets/javascripts/app/discussions/discussions.module.js
@@ -15,7 +15,7 @@
       .state('discussions', {
         url: '/discussions',
         abstract: true,
-        template: '<div ui-view class="u-fullSize"></div>'
+        template: '<div ui-view></div>'
       })
       .state('discussions.index', {
         url: '',

--- a/app/assets/javascripts/app/members/index.html.slim
+++ b/app/assets/javascripts/app/members/index.html.slim
@@ -7,7 +7,7 @@
         a data-method="delete" href="/users/sign_out" Log Out
 
 .TopBarLayout-content
-  .Page.Page--dark.u-fullSize layout='column'
+  .Page.Page--dark layout='column'
     section
       md-container.u-upperCase Team Members
       md-container layout='column' layout-margin=''

--- a/app/assets/javascripts/app/users/users.module.js
+++ b/app/assets/javascripts/app/users/users.module.js
@@ -12,7 +12,7 @@
       .state('users', {
         url: '/users',
         abstract: true,
-        template: '<div ui-view class="u-fullSize"></div>'
+        template: '<div ui-view></div>'
       })
       .state('users.edit', {
         url: '/:id/edit',

--- a/app/assets/stylesheets/components/_page.css.sass
+++ b/app/assets/stylesheets/components/_page.css.sass
@@ -1,4 +1,6 @@
 .Page
+  width: 100%
+  min-height: 100%
   $main-color: theme-palette(primary, light)
   background-color: $main-color
 

--- a/app/assets/stylesheets/utilities/_base.css.sass
+++ b/app/assets/stylesheets/utilities/_base.css.sass
@@ -1,3 +1,2 @@
 @import 'upper_case'
-@import 'full_size'
 @import 'fixed_top'

--- a/app/assets/stylesheets/utilities/_full_size.css.sass
+++ b/app/assets/stylesheets/utilities/_full_size.css.sass
@@ -1,3 +1,0 @@
-.u-fullSize
-  min-height: 100%
-  width: 100%

--- a/app/views/pages/index.html.slim
+++ b/app/views/pages/index.html.slim
@@ -1,1 +1,1 @@
-.u-fullSize(ui-view)
+div(ui-view)


### PR DESCRIPTION
Removed the u-fullSize class, it's now default with Page.

https://trello.com/c/Ys4BWTmp/35-remove-fullsize-class-move-the-rules-to-the-classes-that-use-it
