### PR TITLE
Fixes weird focus effect on login inputs

### DIFF
--- a/app/assets/stylesheets/components/_log_in.css.sass
+++ b/app/assets/stylesheets/components/_log_in.css.sass
@@ -41,8 +41,11 @@ $login-buttons-height: 40px
   .md-input-focused
     input
       border-width: 0 0 2px 0
-      padding: 0 0 10px 0
       border-color: theme-palette(accent-primary, dark)
+
+  .md-council-theme
+    input
+      padding: 0 0 10px 0
 
     label
       color: theme-palette(accent-secondary, dark)


### PR DESCRIPTION
The padding should always be applied, instead of only on focus, which caused the rest of the form to "jump" around
