### PR TITLE
Removes 'members' link from header

### DIFF
--- a/app/assets/javascripts/app/discussions/index.html.slim
+++ b/app/assets/javascripts/app/discussions/index.html.slim
@@ -4,9 +4,8 @@ div ui-view="sidebar"
   .TopBarLayout-header
     md-toolbar.md-whiteframe-z1.Toolbar
       .md-toolbar-tools layout="row" layout-align="space-between center"
-        a.IconNavigation href="" ng-click="ctrl.toggleSidebar()"
-        a href="#/discussions" Council
-        a href="#/members" Members
+        a.IconNavigation href="" ng-click="ctrl.toggleSidebar()" flex="0"
+        a href="#/discussions" flex="1" Council
 
   .TopBarLayout-content
     .Page

--- a/app/assets/javascripts/app/discussions/sidebar.html.slim
+++ b/app/assets/javascripts/app/discussions/sidebar.html.slim
@@ -7,4 +7,6 @@ md-sidenav.Sidebar.md-sidenav-left.md-whiteframe-z2 md-component-id="left" md-is
       li.Sidebar-item Notifications
       li.Sidebar-item Settings
       li.Sidebar-item
+        a.Sidebar-itemInside href="#/members" Members
+      li.Sidebar-item
         a.Sidebar-itemInside data-method="delete" href="/users/sign_out" Sign Out


### PR DESCRIPTION
Removes 'members' from top navbar and puts it on the sidebar 