### PR TITLE
Makes discussion appear "READ" after being open

### DIFF
--- a/app/assets/javascripts/app/core/models/discussion.js
+++ b/app/assets/javascripts/app/core/models/discussion.js
@@ -30,7 +30,6 @@
 
           $http.put('discussions/' + discussion.id + '/subscription')
             .success(function() {
-              console.log('success');
               DS.refresh('discussion', discussion.id);
             });
         },

--- a/app/assets/javascripts/app/core/models/discussion.js
+++ b/app/assets/javascripts/app/core/models/discussion.js
@@ -26,7 +26,13 @@
             .then(refresh);
         },
         markAsRead: function() {
-          return $http.put('discussions/' + this.id + '/subscription');
+          var discussion = this;
+
+          $http.put('discussions/' + discussion.id + '/subscription')
+            .success(function() {
+              console.log('success');
+              DS.refresh('discussion', discussion.id);
+            });
         },
         update: function() {
           return Discussion.save(this, {

--- a/app/models/decorator.rb
+++ b/app/models/decorator.rb
@@ -1,0 +1,5 @@
+class Decorator < SimpleDelegator
+  def class
+    __getobj__.class
+  end
+end

--- a/app/models/subscribed_discussion.rb
+++ b/app/models/subscribed_discussion.rb
@@ -1,0 +1,19 @@
+class SubscribedDiscussion < Decorator
+  def initialize(discussion: discussion, user: user)
+    super(discussion)
+    @discussion = discussion
+    @user = user
+  end
+
+  def subscription_state
+    subscription.state
+  end
+
+  private
+
+  attr_reader :discussion, :user
+
+  def subscription
+    @_subscription ||= Subscription.for(discussion_id: discussion.id, user_id: user.id)
+  end
+end

--- a/app/serializers/concerns/subscribable.rb
+++ b/app/serializers/concerns/subscribable.rb
@@ -1,5 +1,0 @@
-module Subscribable
-  def status
-    Subscription.for(discussion_id: object.id, user_id: scope.id).state
-  end
-end

--- a/app/serializers/concerns/subscribable.rb
+++ b/app/serializers/concerns/subscribable.rb
@@ -1,0 +1,5 @@
+module Subscribable
+  def status
+    Subscription.for(discussion_id: object.id, user_id: scope.id).state
+  end
+end

--- a/app/serializers/discussion_compact_serializer.rb
+++ b/app/serializers/discussion_compact_serializer.rb
@@ -1,5 +1,6 @@
 class DiscussionCompactSerializer < EditableSerializer
-  attributes :id, :title, :subtitle, :body, :open, :url, :comments_count, :updated_at, :status
+  attributes :id, :title, :subtitle, :body, :open, :url,
+    :comments_count, :updated_at, :status
 
   has_one :author
 

--- a/app/serializers/discussion_compact_serializer.rb
+++ b/app/serializers/discussion_compact_serializer.rb
@@ -1,10 +1,10 @@
 require_relative 'concerns/subscribable'
 
 class DiscussionCompactSerializer < EditableSerializer
-  include Subscribable
+  delegate :subscription_state, to: :object
 
   attributes :id, :title, :subtitle, :body, :open, :url,
-    :comments_count, :updated_at, :status
+    :comments_count, :updated_at, :subscription_state
 
   has_one :author
 

--- a/app/serializers/discussion_compact_serializer.rb
+++ b/app/serializers/discussion_compact_serializer.rb
@@ -1,4 +1,8 @@
+require_relative 'concerns/subscribable'
+
 class DiscussionCompactSerializer < EditableSerializer
+  include Subscribable
+
   attributes :id, :title, :subtitle, :body, :open, :url,
     :comments_count, :updated_at, :status
 
@@ -8,9 +12,5 @@ class DiscussionCompactSerializer < EditableSerializer
     return '' unless object.persisted?
 
     discussion_path(object)
-  end
-
-  def status
-    Subscription.for(discussion_id: object.id, user_id: scope.id).state
   end
 end

--- a/app/serializers/discussion_serializer.rb
+++ b/app/serializers/discussion_serializer.rb
@@ -1,11 +1,11 @@
+require_relative 'concerns/subscribable'
+
 class DiscussionSerializer < EditableSerializer
+  include Subscribable
+
   attributes :id, :title, :subtitle, :body, :open,
     :comments_count, :created_at, :status
 
   has_one :author, embed: :ids
   has_many :comments, embed: :objects
-
-  def status
-    Subscription.for(discussion_id: object.id, user_id: scope.id).state
-  end
 end

--- a/app/serializers/discussion_serializer.rb
+++ b/app/serializers/discussion_serializer.rb
@@ -1,10 +1,10 @@
 require_relative 'concerns/subscribable'
 
 class DiscussionSerializer < EditableSerializer
-  include Subscribable
+  delegate :subscription_state, to: :object
 
   attributes :id, :title, :subtitle, :body, :open,
-    :comments_count, :created_at, :status
+    :comments_count, :created_at, :subscription_state
 
   has_one :author, embed: :ids
   has_many :comments, embed: :objects

--- a/app/serializers/discussion_serializer.rb
+++ b/app/serializers/discussion_serializer.rb
@@ -1,6 +1,11 @@
 class DiscussionSerializer < EditableSerializer
-  attributes :id, :title, :subtitle, :body, :open, :comments_count, :created_at
+  attributes :id, :title, :subtitle, :body, :open,
+    :comments_count, :created_at, :status
 
   has_one :author, embed: :ids
   has_many :comments, embed: :objects
+
+  def status
+    Subscription.for(discussion_id: object.id, user_id: scope.id).state
+  end
 end


### PR DESCRIPTION
The status property needs to be added to the DiscussionSerializer.

The problem here is that we are making two requests to get all information on
a discussion.

* The first one is on discussions/index, loading a small ammount of 
information for each discussions.

* The second one is for discussions/show. This requests ignores the cached
values and loads again all the information needed for a single discussion
(except the status).

Once someone opens a discussions/show a request is made to mark that page as
read. After that request we need to refresh the information we have on the
discussion. For this we call the discussions/show again (not the 
discussions/index). For this reason we need it to return status.