### PR TITLE
[DB] Discussion have always the same order

### DIFF
--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -6,8 +6,6 @@ class Discussion < ActiveRecord::Base
   validates_presence_of :title, :open, :author_id, :body
   validates_inclusion_of :open, in: [true, false]
 
-  default_scope -> { order('updated_at DESC') }
-
   after_save :update_subscriptions
 
   private


### PR DESCRIPTION
It's much easier to understand what's happening if each discussion is
always in the same place, except for when there is a new one or one is
closed.

The notifications and color coding on the frontend should be enough to
let you know where/when something is happening.