### PR TITLE
[Models] Improves subscription update system

### DIFF
--- a/app/models/subscriber.rb
+++ b/app/models/subscriber.rb
@@ -1,0 +1,31 @@
+class Subscriber
+  def self.for_discussion(discussion)
+    new(discussion)
+  end
+
+  def initialize(discussion)
+    @discussion = discussion
+    @subscriptions = Subscription.where(discussion_id: discussion.id)
+  end
+
+  def subscribe(users)
+    users.map do |user|
+      subscription_for_user(user)
+    end
+  end
+
+  private
+
+  attr_reader :discussion, :subscriptions
+
+  def subscription_for_user(user)
+    existing_subscription_for_user(user) ||
+      Subscription.create(user: user, discussion: discussion)
+  end
+
+  def existing_subscription_for_user(user)
+    subscriptions.find do |subscription|
+      subscription.user_id == user.id
+    end
+  end
+end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -7,7 +7,7 @@ class Subscription < ActiveRecord::Base
     where(discussion_id: discussion_id, user_id: user_id).first_or_create
   end
 
-  after_create :set_initial_state
+  before_create :set_initial_state
 
   state_machine :state do
     after_transition any => :unread, do: :notify
@@ -39,7 +39,7 @@ class Subscription < ActiveRecord::Base
   def set_initial_state
     return if state
 
-    update state: initial_state
+    self.state = initial_state
   end
 
   def new_comment_by_me?

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,7 +13,7 @@
 
 ActiveRecord::Schema.define(version: 20141215103539) do
 
-  create_table "comments", force: true do |t|
+  create_table "comments", force: :cascade do |t|
     t.text     "body",          null: false
     t.integer  "author_id",     null: false
     t.integer  "discussion_id", null: false
@@ -21,7 +21,7 @@ ActiveRecord::Schema.define(version: 20141215103539) do
     t.datetime "updated_at"
   end
 
-  create_table "discussions", force: true do |t|
+  create_table "discussions", force: :cascade do |t|
     t.string   "title",                         null: false
     t.string   "subtitle"
     t.integer  "author_id",                     null: false
@@ -33,7 +33,7 @@ ActiveRecord::Schema.define(version: 20141215103539) do
     t.integer  "comments_count", default: 0,    null: false
   end
 
-  create_table "subscriptions", force: true do |t|
+  create_table "subscriptions", force: :cascade do |t|
     t.integer  "user_id"
     t.integer  "discussion_id"
     t.string   "state"
@@ -42,7 +42,7 @@ ActiveRecord::Schema.define(version: 20141215103539) do
     t.integer  "first_unread_comment_id"
   end
 
-  create_table "users", force: true do |t|
+  create_table "users", force: :cascade do |t|
     t.string   "email",                  default: "", null: false
     t.string   "encrypted_password",     default: "", null: false
     t.string   "reset_password_token"

--- a/spec/models/discussion_spec.rb
+++ b/spec/models/discussion_spec.rb
@@ -3,12 +3,14 @@ require 'rails_helper'
 describe Discussion do
   context '#touch' do
     it 'updates the subscriptions' do
-      discussion = create(:discussion)
-      subscription = double('subscription', new_comment: true)
-      allow(Subscription).to receive(:for).and_return(subscription)
+      discussion = build(:discussion)
+      subscription = double('Subscription', new_comment: true)
+      subscriber = double('subscriber', subscribe: [subscription])
+      allow(Subscriber).to receive(:for_discussion).and_return(subscriber)
 
       discussion.touch
 
+      expect(subscriber).to have_received(:subscribe)
       expect(subscription).to have_received(:new_comment)
     end
   end

--- a/spec/models/subscriber_spec.rb
+++ b/spec/models/subscriber_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe Subscriber do
+  let(:discussion) { build_stubbed(:discussion) }
+  let(:users) { build_stubbed_list(:user, 2) }
+
+  context 'new discussion, no subscriptions' do
+    it 'creates a subscription for each user' do
+      subscriber = Subscriber.for_discussion(discussion)
+
+      expect do
+        subscriber.subscribe(users)
+      end.to change { Subscription.count }.by(users.count)
+    end
+  end
+
+  context 'some users already have subscriptions to discussion' do
+    it 'only creates subcriptions for the users who do not have one' do
+      create(:subscription, user: users.first, discussion: discussion)
+      subscriber = Subscriber.for_discussion(discussion)
+
+      expect do
+        subscriber.subscribe(users)
+      end.to change { Subscription.count }.by(users.count - 1)
+    end
+  end
+end


### PR DESCRIPTION
Gets all the subscriptions in bulk and searches in memory, instead of a
query per user. Also calls the subscription set_initial_state callback
before save, instead of after, thus saving an access to the db per new
subscription created.

Moves the logic of creating subscriptions into it's own object. This
still does not deal with users unsubscribing to discussion, but it's a
step towards that.