### PR TITLE
Change comment form to the bottom of comments on desktop

### DIFF
--- a/app/assets/javascripts/app/components/comment_form/comment_form.js
+++ b/app/assets/javascripts/app/components/comment_form/comment_form.js
@@ -12,7 +12,8 @@
       scope: {
         toggle: "=toggle",
         comment: "=comment",
-        discussion: "=discussion"
+        discussion: "=discussion",
+        isMobile: "=mobile"
       },
       templateUrl: 'components/comment_form/templates/comment_form.html',
       link: function($scope, element, attrs) {

--- a/app/assets/javascripts/app/components/comment_form/templates/comment_form.html.slim
+++ b/app/assets/javascripts/app/components/comment_form/templates/comment_form.html.slim
@@ -1,12 +1,20 @@
-.TopBarLayout
+.TopBarLayout ng-show="isMobile"
   .TopBarLayout-header
     md-toolbar md-theme="white" on-scroll="" on-scroll-anchor="#js-comment-content" scrolling-class="md-whiteframe-z1" layout="row" layout-align="space-between center"
-        md-button.md-primary.md-warn md-no-ink="" ng-click="toggle()" md-theme="council" layout="row" layout-align="space-between center"
-          .IconClose
-          | hide
+      md-button.md-primary.md-warn md-no-ink="" ng-click="toggle()" md-theme="council" layout="row" layout-align="space-between center"
+        .IconClose
+        | hide
 
-        council-raised-button.Button.Button--secondary ng-click="create(comment)"
-          | Add Comment
+      council-raised-button.Button.Button--secondary ng-click="create(comment)"
+        | Add Comment
+
   .TopBarLayout-content
     .Page.Page--white.u-fullSize
       textarea.Editor placeholder="State your arguments" ng-model="comment.body" id="js-comment-content"
+
+.CardList ng-hide="isMobile" layout="column"
+  md-card.Comment id="newComment"
+    textarea.Editor placeholder="State your arguments" ng-model="comment.body" id="js-comment-content"
+    md-toolbar md-theme="white" on-scroll="" on-scroll-anchor="#js-comment-content" scrolling-class="md-whiteframe-z1" layout="row" layout-align="end center"
+      council-raised-button.Button.Button--secondary ng-click="create(comment)"
+        | Add Comment

--- a/app/assets/javascripts/app/discussions/discussion.js
+++ b/app/assets/javascripts/app/discussions/discussion.js
@@ -5,12 +5,15 @@
     .module('council.discussions')
     .controller('DiscussionCtrl', DiscussionCtrl);
 
-  function DiscussionCtrl(Discussion, User, discussionId, _, DS) {
+  function DiscussionCtrl(Discussion, User, discussionId, _, DS, $location, $anchorScroll) {
     var ctrl = this;
 
     ctrl.pageReady = false;
+    ctrl.scrollTo = scrollTo;
     ctrl.toggleNewComment = toggleNewComment;
     ctrl.toogleDiscussionState = toogleDiscussionState;
+
+    ctrl.mobileDetect = new MobileDetect(window.navigator.userAgent);
 
     ctrl.newComment = {
       discussionId: discussionId
@@ -19,6 +22,11 @@
     Discussion
       .find(discussionId)
       .then(updateDiscussion);
+
+    function scrollTo(location) {
+      $location.hash(location);
+      $anchorScroll();
+    }
 
     function toogleDiscussionState(discussion) {
       discussion.open = !discussion.open;
@@ -52,7 +60,10 @@
     }
 
     function toggleNewComment() {
-      ctrl.showNewComment = !ctrl.showNewComment;
+      if(ctrl.mobileDetect.mobile())
+        ctrl.showNewComment = !ctrl.showNewComment;
+      else
+        scrollTo('newComment');
     }
   }
 })();

--- a/app/assets/javascripts/app/discussions/show.html.slim
+++ b/app/assets/javascripts/app/discussions/show.html.slim
@@ -36,6 +36,7 @@
 
       md-content.md-padding md-theme="white"
         div layout="column" comments-list="ctrl.discussion.comments" comment-count="ctrl.discussion.comments_count"
+        comment-form ng-hide="ctrl.mobileDetect.mobile()" toggle="ctrl.toggleNewComment" mobile="ctrl.mobileDetect.mobile()" comment="ctrl.newComment" discussion="ctrl.discussion"
 
-sliding-screen show="ctrl.showNewComment" hide-bottom=""
-  comment-form toggle="ctrl.toggleNewComment" comment="ctrl.newComment" discussion="ctrl.discussion"
+sliding-screen ng-show="ctrl.mobileDetect.mobile()" show="ctrl.showNewComment" hide-bottom=""
+  comment-form toggle="ctrl.toggleNewComment" comment="ctrl.newComment" discussion="ctrl.discussion" mobile="ctrl.mobileDetect.mobile()"

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,6 +10,7 @@
 //= require angular-aria/angular-aria
 //= require hammerjs/hammer
 //= require konami-js/konami
+//= require mobile-detect/mobile-detect
 //= require angular-rails-templates
 //= require angular-ui-router/release/angular-ui-router
 //= require angular-data/dist/angular-data

--- a/app/assets/stylesheets/components/_sliding_screen.css.sass
+++ b/app/assets/stylesheets/components/_sliding_screen.css.sass
@@ -1,5 +1,4 @@
 .SlidingScreen
-  left: 0
   height: 100%
   position: fixed
   top: 0

--- a/app/assets/stylesheets/components/_theme.css.scss
+++ b/app/assets/stylesheets/components/_theme.css.scss
@@ -154,7 +154,7 @@ md-toolbar {
 $theme-breakpoint-desktop: 600px;
 
 /** Layout **/
-$layout-max-width: 960px;
+$layout-max-width: 640px;
 
 [layout=column] {
   max-width: $layout-max-width;

--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,7 @@
     "fastclick": "~1.0.3",
     "konami-js": "*",
     "lodash": "*",
-    "ng-fastclick": "*"
+    "ng-fastclick": "*",
+    "mobile-detect": "hgoebl/mobile-detect.js#~0.4.3"
   }
 }


### PR DESCRIPTION
Adds comment form on the bottom of the comments list when on desktop. This probably isn't the cleaner way to do it but this is intended to change in the next months.
Also the 'Pitch In' button scrolls to the comment form when on desktop.

![screen shot 2015-01-15 at 23 26 30](https://cloud.githubusercontent.com/assets/4236592/5768996/fce0963c-9d0d-11e4-82bc-bef0b418d955.png)

