### PR TITLE
Mp notifications

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,7 +15,7 @@
 //= require angular-ui-router/release/angular-ui-router
 //= require angular-data/dist/angular-data
 //= require angular-emoji-filter-hd/dist/emoji.min
-//= require lodash/lodash
+//= require lodash/dist/lodash
 //= require jquery
 //= require jquery_ujs
 //= require ./app/app

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,0 +1,10 @@
+class NotificationsController < ApplicationController
+  def index
+    render json: current_user.notifications
+  end
+
+  def destroy
+    Notification.where(id: params[:id]).first.destroy
+    head 200
+  end
+end

--- a/app/mailers/notifications_mailer.rb
+++ b/app/mailers/notifications_mailer.rb
@@ -2,9 +2,9 @@ class NotificationsMailer < ActionMailer::Base
   default 'app_name' => 'Council'
   default from: 'hq@groupbuddies.com'
 
-  def new_comment(subscription_id)
-    @subscription = Subscription.find(subscription_id)
+  def new_notification(notification_id)
+    @notification = Notification.where(id: notification_id).first
 
-    mail to: @subscription.user.email, subject: "[Council] New comment in #{@subscription.discussion.title}"
+    mail to: @notification.email, subject: "[Council] #{@notification.text}"
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -5,4 +5,12 @@ class Comment < ActiveRecord::Base
   validates_presence_of :body, :author_id, :discussion_id
 
   default_scope -> { order('created_at ASC') }
+
+  after_create :subscribe_author
+
+  private
+
+  def subscribe_author
+    Subscriber.for_discussion(discussion).subscribe([author])
+  end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,0 +1,43 @@
+class Notification < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :discussion
+
+  validates :text, :url, :user, presence: true
+
+  delegate :email, to: :user
+
+  after_create :send_email
+
+  def self.new_comment(user: user, comment: comment)
+    discussion = comment.discussion
+    create(
+      discussion_id: discussion.id,
+      user_id: user.id,
+      text: I18n.t('notifications.new_comment', author: comment.author.display_name, discussion: discussion.title),
+      url: root_url(anchor: "#/discussion/#{discussion.id}/comments/#{comment.id}")
+    )
+  end
+
+  def self.new_discussion(user: user, discussion: discussion)
+    create(
+      discussion_id: discussion.id,
+      user_id: user.id,
+      text: I18n.t('notifications.new_discussion', author: discussion.author, discussion: discussion.title),
+      url: root_url(anchor: "#/discussion/#{discussion.id}")
+    )
+  end
+
+  private
+
+  def send_email
+    NotificationsMailer.new_notification(id).deliver_later
+  end
+
+  def self.root_url(*args)
+    Rails.application.routes.url_helpers.root_url(*args, host: default_url_options[:host])
+  end
+
+  def self.default_url_options
+    ActionMailer::Base.default_url_options
+  end
+end

--- a/app/models/subscriber.rb
+++ b/app/models/subscriber.rb
@@ -10,7 +10,7 @@ class Subscriber
 
   def subscribe(users)
     users.map do |user|
-      subscription_for_user(user)
+      subscribe_user(user)
     end
   end
 
@@ -18,12 +18,12 @@ class Subscriber
 
   attr_reader :discussion, :subscriptions
 
-  def subscription_for_user(user)
-    existing_subscription_for_user(user) ||
+  def subscribe_user(user)
+    subscription_for_user(user) ||
       Subscription.create(user: user, discussion: discussion)
   end
 
-  def existing_subscription_for_user(user)
+  def subscription_for_user(user)
     subscriptions.find do |subscription|
       subscription.user_id == user.id
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,8 @@ class User < ActiveRecord::Base
     :validatable,
     :recoverable
 
+  has_many :notifications
+
   validates :first_name, :last_name, :email, presence: true
 
   def display_name

--- a/app/serializers/notification_serializer.rb
+++ b/app/serializers/notification_serializer.rb
@@ -1,0 +1,3 @@
+class NotificationSerializer < ActiveModel::Serializer
+  attributes :id, :user_id, :text, :url
+end

--- a/app/views/notifications_mailer/new_comment.slim
+++ b/app/views/notifications_mailer/new_comment.slim
@@ -1,3 +1,0 @@
-h1 = "New comments in '#{@subscription.discussion.title}'"
-
-h2 = link_to 'Go to discussion', root_url(anchor: "/discussions/#{@subscription.discussion.id}")

--- a/app/views/notifications_mailer/new_notification.slim
+++ b/app/views/notifications_mailer/new_notification.slim
@@ -1,0 +1,3 @@
+h1 = @notification.text
+
+h2 = link_to 'See it on Council', @notification.url

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.eager_load = false
 
   # Configure static asset server for tests with Cache-Control for performance.
-  config.serve_static_assets  = true
+  config.serve_static_files  = true
   config.static_cache_control = 'public, max-age=3600'
 
   # Show full error reports and disable caching.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,3 +9,7 @@ en:
       default: '%a, %b %-d, %Y at %r'
       date: '%b %-d, %Y'
       short: '%B %d'
+
+  notifications:
+    new_discussion: '%{author} created %{discussion}'
+    new_comment: '%{author} commented on %{discussion}'

--- a/db/migrate/20150109180300_create_notifications_again.rb
+++ b/db/migrate/20150109180300_create_notifications_again.rb
@@ -1,0 +1,9 @@
+class CreateNotificationsAgain < ActiveRecord::Migration
+  def change
+    create_table :notifications do |t|
+      t.references :user
+      t.string :url
+      t.string :text
+    end
+  end
+end

--- a/db/migrate/20150112155620_add_discussion_id_to_notifications.rb
+++ b/db/migrate/20150112155620_add_discussion_id_to_notifications.rb
@@ -1,0 +1,5 @@
+class AddDiscussionIdToNotifications < ActiveRecord::Migration
+  def change
+    add_column :notifications, :discussion_id, :integer
+  end
+end

--- a/db/migrate/20150130131405_remove_first_unread_comment_from_subscriptions.rb
+++ b/db/migrate/20150130131405_remove_first_unread_comment_from_subscriptions.rb
@@ -1,0 +1,5 @@
+class RemoveFirstUnreadCommentFromSubscriptions < ActiveRecord::Migration
+  def change
+    remove_column :subscriptions, :first_unread_comment_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150120141450) do
+ActiveRecord::Schema.define(version: 20150130131405) do
 
   create_table "comments", force: :cascade do |t|
     t.text     "body",          null: false
@@ -46,7 +46,6 @@ ActiveRecord::Schema.define(version: 20150120141450) do
     t.string   "state"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "first_unread_comment_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -64,7 +63,6 @@ ActiveRecord::Schema.define(version: 20150120141450) do
     t.datetime "updated_at"
     t.string   "first_name",             default: "", null: false
     t.string   "last_name",              default: "", null: false
-    t.string   "access_token"
     t.string   "username"
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -19,6 +19,12 @@ FactoryGirl.define do
     body { Faker::Lorem.paragraphs(1) }
   end
 
+  factory :notification do
+    association :user
+    text { Faker::Lorem.words }
+    url { Faker::Internet.url }
+  end
+
   factory :user, aliases: [:author] do
     first_name { Faker::Name.first_name }
     last_name  { Faker::Name.last_name }

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe Comment do
+  context '#create' do
+    it "subscribes the user to the comment's discussion" do
+      discussion = build_stubbed(:discussion)
+      subscriber = double('subscriber', subscribe: true)
+      allow(Subscriber).to receive(:for_discussion).and_return(subscriber)
+
+      create(:comment, discussion: discussion)
+
+      expect(subscriber).to have_received(:subscribe)
+    end
+  end
+end

--- a/spec/models/discussion_spec.rb
+++ b/spec/models/discussion_spec.rb
@@ -2,16 +2,24 @@ require 'rails_helper'
 
 describe Discussion do
   context '#touch' do
-    it 'updates the subscriptions' do
+    it 'send a new comment notification' do
       discussion = create(:discussion)
       subscription = double('Subscription', new_comment: true)
-      subscriber = double('subscriber', subscribe: [subscription])
-      allow(Subscriber).to receive(:for_discussion).and_return(subscriber)
+      allow(discussion).to receive(:subscriptions).and_return([subscription])
 
       discussion.touch
 
-      expect(subscriber).to have_received(:subscribe)
       expect(subscription).to have_received(:new_comment)
+    end
+  end
+
+  context '#create' do
+    it 'notifies all users' do
+      allow(Notification).to receive(:new_discussion)
+
+      create(:discussion)
+
+      expect(Notification).to have_received(:new_discussion)
     end
   end
 end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe Notification, type: :model do
+  context '.new_comment' do
+    it 'creates a comment notification for a user' do
+      comment = create :comment
+      user = create :user
+
+      notification = Notification.new_comment(user: user, comment: comment)
+
+      expect(notification).to be_persisted
+    end
+  end
+
+  context '#send_email' do
+    it 'sends an email after creation' do
+      create :notification
+
+      expect(ActionMailer::Base.deliveries.count).to eq 1
+    end
+  end
+end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -2,19 +2,19 @@ require 'rails_helper'
 
 describe Subscription, type: :model do
   context '.for' do
-    it 'fetches an existing subscription' do
-      subscription = create(:subscription)
+    it 'returns an existing subscription' do
+      discussion = create(:discussion)
+      subscription = create(:subscription, discussion: discussion)
 
-      fetched_subscription = Subscription.for(discussion_id: subscription.discussion_id, user_id: subscription.user_id)
+      fetched_subscription = Subscription.for(discussion_id: discussion.id, user_id: subscription.user_id)
 
       expect(fetched_subscription).to eq subscription
     end
 
-    it "creates a subscription when one doesn't exist" do
-      user = create(:user)
+    it 'creates a subscription' do
       discussion = create(:discussion)
 
-      subscription = Subscription.for(user_id: user.id, discussion_id: discussion.id)
+      subscription = Subscription.for(discussion_id: discussion.id)
 
       expect(subscription).to be
     end
@@ -23,32 +23,30 @@ describe Subscription, type: :model do
   context '.create' do
     context "Subscription of the discussions's author" do
       it 'sets the initial state to :read' do
-        author = create(:author)
-        discussion = create(:discussion, author: author)
-        subscription = create(:subscription, discussion: discussion, user: author)
+        subscription = create(:subscription, state: nil)
 
         expect(subscription).to be_read
       end
     end
 
     context 'Subscription of a user who did not author the discussion' do
-      it 'sets the initial state to :new' do
+      it 'sets the initial state to :read' do
         discussion = create(:discussion, author: create(:user))
         subscription = create(:subscription, discussion: discussion, user: create(:user))
 
-        expect(subscription).to be_new
+        expect(subscription).to be_read
       end
     end
   end
 
-  context '#make_viewed' do
+  context '#make_read' do
     context 'A new discussion' do
-      it 'changes to unwatch' do
-        subscription = create(:subscription, state: :new)
+      it 'changes to read' do
+        subscription = create(:subscription, state: :unread)
 
-        subscription.make_viewed
+        subscription.make_read
 
-        expect(subscription).to be_unwatched
+        expect(subscription).to be_read
       end
     end
 
@@ -56,7 +54,7 @@ describe Subscription, type: :model do
       it 'remains read' do
         subscription = create(:subscription, state: :read)
 
-        subscription.make_viewed
+        subscription.make_read
 
         expect(subscription).to be_read
       end
@@ -66,66 +64,52 @@ describe Subscription, type: :model do
       it 'changes to read' do
         subscription = create(:subscription, state: :unread)
 
-        subscription.make_viewed
+        subscription.make_read
 
         expect(subscription).to be_read
       end
-    end
-  end
 
-  context '#unwatch' do
-    context 'A read discussion' do
-      it 'changes to unwatch' do
-        subscription = create(:subscription, state: :read)
-
-        subscription.unwatch
-
-        expect(subscription).to be_unwatched
-      end
-    end
-
-    context 'An unread discussion' do
-      it 'changes to unwatch' do
+      it 'destroys all related notifications' do
         subscription = create(:subscription, state: :unread)
-        subscription.unwatch
+        create(:notification, user: subscription.user, discussion: subscription.discussion)
 
-        expect(subscription).to be_unwatched
+        subscription.make_read
+
+        expect(subscription.notifications.count).to be(0)
       end
     end
   end
 
   context '#new_comment' do
-    context 'A new discussion' do
-      it 'remains new' do
-        subscription = create(:subscription, state: :new)
+    context 'new_comment by me' do
+      it 'remains read' do
+        subscription = create(:subscription, state: :read)
+        create(:comment, discussion: subscription.discussion, author: subscription.user)
 
         subscription.new_comment
 
-        expect(subscription).to be_new
+        expect(subscription).to be_read
       end
     end
 
-    context 'A read discussion' do
-      context 'new_comment by me' do
-        it 'remains read' do
-          subscription = create(:subscription, state: :read)
-          create(:comment, discussion: subscription.discussion, author: subscription.user)
+    context 'new_comment by someone else' do
+      it 'changes to unread' do
+        subscription = create(:subscription, state: :read)
 
-          subscription.new_comment
+        subscription.new_comment
 
-          expect(subscription).to be_read
-        end
+        expect(subscription).to be_unread
       end
+    end
 
-      context 'new_comment by someone else' do
-        it 'changes to unread' do
-          subscription = create(:subscription, state: :read)
+    it 'creates a notification' do
+      user = create :user
+      subscription = create(:subscription, state: :read, user: user)
+      create(:comment, discussion: subscription.discussion)
 
-          subscription.new_comment
-
-          expect(subscription).to be_unread
-        end
-      end
+      expect do
+        subscription.new_comment
+      end.to change { user.notifications.count }.by(1)
     end
   end
 end

--- a/spec/support/mailer.rb
+++ b/spec/support/mailer.rb
@@ -1,0 +1,5 @@
+RSpec.configure do |config|
+  config.before(:each) do
+    ActionMailer::Base.deliveries = []
+  end
+end


### PR DESCRIPTION
This is a change to how the backend handles subscriptions, now to accomodate for notifications as well.
The current flow is:

* A subscription is created for each user-subscription pair
* Whenever a subscription is updated (which happens in two different ways: discussion created, and discussion commented), a notification will be generated
* This notification, in turn, sends an email to the user

This means we'll now be notified by email not only on new comments, but also when discussions are created.
The main reason for this is to allow for in-app notifications as well

Probably some people will complain about the spam this generates. A temporary solution for that is for each of us to use gmail filters. Other solutions can be thought about later