### PR TITLE
Comemnts are loaded from a different route

### DIFF
--- a/app/assets/javascripts/app/components/comments_list/comments_list.js
+++ b/app/assets/javascripts/app/components/comments_list/comments_list.js
@@ -17,7 +17,7 @@
     };
   }
 
-  function CommentsListCtrl(DS, $stateParams) {
+  function CommentsListCtrl(Comment, $stateParams) {
     var ctrl = this;
 
     ctrl.editing = null;
@@ -27,9 +27,9 @@
     ctrl.cancelEdit = cancelEdit;
 
     function updateComment(comment) {
-      var updated = DS.createInstance('comment', comment, { useClass:true });
-
-      updated.update(ctrl.editing.body).then(refreshComment);
+      Comment
+        .update(comment.id, comment)
+        .then(refreshComment);
 
       function refreshComment(comment) {
         angular.extend(ctrl.editing, comment);

--- a/app/assets/javascripts/app/core/models/comment.js
+++ b/app/assets/javascripts/app/core/models/comment.js
@@ -5,22 +5,10 @@
     .module('council.core')
     .factory('Comment', Comment);
 
-  function Comment(User, DS, $http) {
+  function Comment(User, DS, $http, _) {
     var Comment = DS.defineResource({
       name: 'comment',
       endpoint: 'comments',
-      methods: {
-        update: function(body) {
-          var url = 'discussions/' + this.discussion_id + '/comments/' + this.id;
-          var data = {
-            body: body
-          };
-
-          return $http.put(url, data).then(function(response) {
-            return response.data;
-          });
-        }
-      },
 
       relations: {
         belongsTo: {
@@ -36,8 +24,14 @@
         }
       },
 
+      beforeUpdate: function(resourename, attrs, cb) {
+        attrs = _.pick(attrs, 'body');
+        cb(null, attrs);
+      },
+
       afterInject: function(name, comment) {
-        DS.loadRelations('comment', comment, ['user'])
+        DS.loadRelations('comment', comment, ['user']);
+        DS.linkInverse('comment', comment.id);
       }
     });
 

--- a/app/assets/javascripts/app/core/models/discussion.js
+++ b/app/assets/javascripts/app/core/models/discussion.js
@@ -5,7 +5,7 @@
     .module('council.core')
     .factory('Discussion', Discussion);
 
-  function Discussion(Comment, DS, $http) {
+  function Discussion(Comment, DS, $http, _) {
     var ALLOWED_FIELDS = 'title subtitle body open tags'.split(' ');
 
     var Discussion = DS.defineResource({
@@ -16,8 +16,7 @@
         addComment: function(comment) {
           var discussion = this;
 
-          return DS.create('comment', comment, {
-            linkInverse: true,
+          return Comment.create(comment, {
             endpoint: 'discussions/' + discussion.id + '/comments'
           });
         },
@@ -36,6 +35,10 @@
           var discussion = this;
 
           return DS.refresh('discussion', discussion.id);
+        },
+
+        loadComments: function() {
+          return Comment.findAll({ discussion_id: this.id});
         }
       },
 

--- a/app/assets/javascripts/app/discussions/discussion.js
+++ b/app/assets/javascripts/app/discussions/discussion.js
@@ -14,25 +14,19 @@
 
     Discussion
       .find(discussionId)
-      .then(updateDiscussion);
+      .then(setDiscussion);
+
+    function setDiscussion(discussion) {
+      ctrl.discussion = discussion;
+      ctrl.discussion.markAsRead();
+      ctrl.pageReady = true;
+
+      discussion.loadComments();
+    }
 
     function toogleDiscussionState(discussion) {
       discussion.open = !discussion.open;
       discussion.update();
-    }
-
-    function updateDiscussion(discussion) {
-      resetController(discussion);
-
-      discussion
-        .refresh()
-        .then(resetController);
-    }
-
-    function resetController(discussion) {
-      ctrl.discussion = discussion;
-      ctrl.discussion.markAsRead();
-      ctrl.pageReady = true;
     }
 
     function toggleNewComment() {

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -2,6 +2,10 @@ class CommentsController < ApplicationController
   authorize_resource
   skip_authorize_resource only: [:update]
 
+  def index
+    render json: discussion.comments
+  end
+
   def show
     comment = discussion.comments.find(params[:id])
 

--- a/app/serializers/discussion_serializer.rb
+++ b/app/serializers/discussion_serializer.rb
@@ -3,7 +3,6 @@ class DiscussionSerializer < EditableSerializer
     :url, :comments_count, :created_at, :updated_at, :status
 
   has_one :author, embed: :ids
-  has_many :comments, embed: :objects
 
   def url
     return '' unless object.persisted?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   defaults format: 'json' do
     constraints format: 'json' do
       resources :discussions, only: [:index, :show, :create, :update] do
-        resources :comments, only: [:show, :create, :update]
+        resources :comments, except: :destroy
         resource :subscription, only: [:update]
       end
       resources :notifications, only: [:index, :destroy]


### PR DESCRIPTION
Removes comments from the discussion serializer. Now, after entering a
discussion/show a request is made to fetch the comments of the corresponding
discussion.