### PR TITLE
Makes last name optional

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,13 +9,19 @@ class User < ActiveRecord::Base
 
   has_many :notifications
 
-  validates :first_name, :last_name, :email, presence: true
+  validates :first_name, :email, presence: true
 
   def display_name
-    username.presence || [first_name, last_name].join(' ')
+    username.presence || full_name
   end
 
   def name=(name)
     self.first_name, self.last_name = name.split(' ', 2)
+  end
+
+  private
+
+  def full_name
+    [first_name, last_name].join(' ').strip
   end
 end

--- a/db/migrate/20150408155101_changes_users_optional_fields.rb
+++ b/db/migrate/20150408155101_changes_users_optional_fields.rb
@@ -1,0 +1,5 @@
+class ChangesUsersOptionalFields < ActiveRecord::Migration
+  def change
+    change_column_null :users, :last_name, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150225120609) do
+ActiveRecord::Schema.define(version: 20150408155101) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -83,7 +83,7 @@ ActiveRecord::Schema.define(version: 20150225120609) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "first_name",             default: "", null: false
-    t.string   "last_name",              default: "", null: false
+    t.string   "last_name",              default: ""
     t.string   "access_token"
     t.string   "username"
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -23,6 +23,17 @@ describe User do
 
         expect(display_name).to eq "#{expected_first_name} #{expected_last_name}"
       end
+
+      context 'last name does not exist' do
+        it 'shows only the first name' do
+          expected_first_name = 'user'
+          user = User.new(first_name: expected_first_name)
+
+          display_name = user.display_name
+
+          expect(display_name).to eq expected_first_name
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes issue https://github.com/groupbuddies/council/issues/119

HQ does not garantees the existance of a last name.
For this reason I made the last name an optional field in Council.