### PR TITLE
Fix scroll on mobile devices

### DIFF
--- a/app/assets/javascripts/app/app.js
+++ b/app/assets/javascripts/app/app.js
@@ -17,18 +17,26 @@
       'dbaq.emoji'
     ])
     .config(csrf)
-    .config(theme);
+    .config(theme)
+    .run(preventOverscroll);
 
-    function csrf($httpProvider) {
-      $httpProvider.defaults.headers.common['X-CSRF-Token'] = $('meta[name=csrf-token]').attr('content');
-    }
+  function csrf($httpProvider) {
+    $httpProvider.defaults.headers.common['X-CSRF-Token'] = $('meta[name=csrf-token]').attr('content');
+  }
 
-    function theme($mdThemingProvider) {
-      $mdThemingProvider.theme('council')
-        .primaryColor('blue-grey', {
-          'hue-1': 'A700'
-        })
-        .accentColor('amber')
-        .warnColor('teal');
-    }
+  function theme($mdThemingProvider) {
+    $mdThemingProvider.theme('council')
+      .primaryColor('blue-grey', {
+        'hue-1': 'A700'
+      })
+      .accentColor('amber')
+      .warnColor('teal');
+  }
+
+  function preventOverscroll($document) {
+    $document.find('body').on('touchmove', function(e) {
+      if (!$('.TopBarLayout-content').has($(e.target)).length)
+        e.preventDefault();
+    });
+  }
 })();

--- a/app/assets/stylesheets/components/_detailed_discussion.css.sass
+++ b/app/assets/stylesheets/components/_detailed_discussion.css.sass
@@ -1,5 +1,7 @@
 .DetailedDiscussion
   background: theme-palette(neutral, white)
+  // necessary to override md-content
+  overflow: hidden
 
 .DetailedDiscussion-title
   @include alpha

--- a/app/assets/stylesheets/components/_top_bar_layout.css.sass
+++ b/app/assets/stylesheets/components/_top_bar_layout.css.sass
@@ -1,17 +1,17 @@
 .TopBarLayout
-  position: relative
   height: 100%
 
 .TopBarLayout-header
-  position: absolute
+  position: fixed
+  top: 0
+  left: 0
   z-index: 9000
   height: $toolbar-height
   width: 100%
 
 .TopBarLayout-content
-  position: absolute
-  top: $toolbar-height
+  padding-top: $toolbar-height
+  height: 100%
+  width: 100%
   overflow: scroll
   -webkit-overflow-scrolling: touch
-  width: 100%
-  height: calc(100% - #{$toolbar-height})


### PR DESCRIPTION
Changing the header to fixed prevents it being scrolled with the main
body (there are no more issues with fixed elements on mobile browsers).

Disabling the mouchemove form everything but the content prevents the
page from overscrolling on touch events.

md-cards has overscroll enabled that causes a strange scroll on
the discussion details.