### PR TITLE
Replace material toolbar

### DIFF
--- a/app/assets/javascripts/app/components/toolbar/toolbar.js
+++ b/app/assets/javascripts/app/components/toolbar/toolbar.js
@@ -1,0 +1,33 @@
+(function() {
+  'use strict';
+
+  angular
+    .module('council.components')
+    .directive('toolbar', toolbar)
+    .directive('toolbarIcon', toolbarIcon);
+
+  function toolbar() {
+    return {
+      restict: 'E',
+      replace: true,
+      transclude: true,
+      templateUrl: 'components/toolbar/toolbar_tpl.html',
+      scope: {
+        shadow: '@', // send value 'enabled' to enable shadows
+        style: '@' // supported values: 'alternative' and 'accent'
+      }
+    };
+  }
+
+  function toolbarIcon() {
+    return {
+      restrict: 'E',
+      replace: true,
+      transclude: true,
+      templateUrl: 'components/toolbar/toolbar_icon_tpl.html',
+      scope: {
+        align: '@' // supported values: 'left'
+      }
+    };
+  }
+})();

--- a/app/assets/javascripts/app/components/toolbar/toolbar_icon_tpl.html.slim
+++ b/app/assets/javascripts/app/components/toolbar/toolbar_icon_tpl.html.slim
@@ -1,0 +1,2 @@
+ng-transclude.Toolbar-icon(
+  ng-class="{ 'Toolbar-iconLeft': align == 'left' }")

--- a/app/assets/javascripts/app/components/toolbar/toolbar_tpl.html.slim
+++ b/app/assets/javascripts/app/components/toolbar/toolbar_tpl.html.slim
@@ -1,0 +1,6 @@
+ng-transclude.Toolbar(
+  ng-class="{
+    'Toolbar--withShadow': shadow == 'enabled',
+    'Toolbar--alternative': style == 'alternative',
+    'Toolbar--accent': style == 'accent'
+  }")

--- a/app/assets/javascripts/app/discussions/discussions.module.js
+++ b/app/assets/javascripts/app/discussions/discussions.module.js
@@ -29,16 +29,6 @@
           }
         }
       })
-      .state('discussions.show', {
-        url: '/:id',
-        templateUrl: 'discussions/show/show.html',
-        controller: 'DiscussionCtrl as ctrl',
-        resolve: {
-          discussion: function($stateParams, Discussion) {
-            return Discussion.find($stateParams.id, { bypassCache: true });
-          }
-        }
-      })
       .state('discussions.new', {
         url: '/new',
         templateUrl: 'discussions/new/templates/discussion.html',
@@ -46,6 +36,16 @@
         resolve: {
           discussion: function(Discussion) {
             return Discussion.createInstance();
+          }
+        }
+      })
+      .state('discussions.show', {
+        url: '/:id',
+        templateUrl: 'discussions/show/show.html',
+        controller: 'DiscussionCtrl as ctrl',
+        resolve: {
+          discussion: function($stateParams, Discussion) {
+            return Discussion.find($stateParams.id, { bypassCache: true });
           }
         }
       })

--- a/app/assets/javascripts/app/discussions/index/index.html.slim
+++ b/app/assets/javascripts/app/discussions/index/index.html.slim
@@ -2,14 +2,14 @@ div ui-view="sidebar"
 
 .TopBarLayout
   .TopBarLayout-header
-    md-toolbar.md-whiteframe-z1.Toolbar layout="row" layout-align="space-between center"
-      .Toolbar-iconLeft
+    toolbar shadow="enabled"
+      toolbar-icon(align="left")
         a.IconNavigation href="" ng-click="ctrl.toggleSidebar()"
           .IconNavigation-count ng-show="ctrl.notifications()"
             | {{ ctrl.notifications() }}
-      .Toolbar-icon
+      toolbar-icon
         .IconLogo.u-topBarCenterLogo
-      .Toolbar-icon
+      toolbar-icon
 
   .TopBarLayout-content
     .Page

--- a/app/assets/javascripts/app/discussions/new/templates/desktop.html.slim
+++ b/app/assets/javascripts/app/discussions/new/templates/desktop.html.slim
@@ -1,6 +1,6 @@
 TopBarLayout
   .TopBarLayout-header
-    md-toolbar.md-whiteframe-z1.md-accent layout="row" layout-align="space-between center"
+    toolbar shadow="enabled" style="accent"
       md-button.md-primary.md-hue-1 md-no-ink="" ui-sref="discussions.index" layout="row" layout-align="center center"
         .IconClose
         |  cancel

--- a/app/assets/javascripts/app/discussions/new/templates/desktop_edit.html.slim
+++ b/app/assets/javascripts/app/discussions/new/templates/desktop_edit.html.slim
@@ -1,11 +1,18 @@
 .TopBarLayout
   .TopBarLayout-header
-    md-toolbar.md-whiteframe-z1.md-accent layout="row" layout-align="space-between center"
-      md-button.md-primary.md-hue-1 md-no-ink="" ui-sref="discussions.index" layout="row" layout-align="center center"
+    toolbar shadow="enabled" style="accent"
+      md-button.md-primary.md-hue-1(
+        md-no-ink=""
+        ui-sref="discussions.show(ctrl.discussion)"
+        layout="row"
+        layout-align="center center")
         .IconClose
         |  cancel
 
-      md-button.md-raised.md-warn md-no-ink="" ng-click="ctrl.saveDiscussion(ctrl.discussion)" ng-disabled="!ctrl.form.$valid || ctrl.submited"
+      md-button.md-raised.md-warn(
+        md-no-ink=""
+        ng-click="ctrl.saveDiscussion(ctrl.discussion)"
+        ng-disabled="!ctrl.form.$valid || ctrl.submited")
         | update discussion
 
 .TopBarLayout-content

--- a/app/assets/javascripts/app/discussions/new/templates/mobile_edit_step1.html.slim
+++ b/app/assets/javascripts/app/discussions/new/templates/mobile_edit_step1.html.slim
@@ -1,6 +1,6 @@
 .TopBarLayout
   .TopBarLayout-header
-    md-toolbar.md-whiteframe-z1.md-accent layout="row" layout-align="space-between center"
+    toolbar shadow="enabled" style="accent"
       md-button.md-primary.md-hue-1 md-no-ink="" ui-sref="discussions.index" layout="row" layout-align="center center"
         .IconClose
         |  cancel

--- a/app/assets/javascripts/app/discussions/new/templates/mobile_edit_step2.html.slim
+++ b/app/assets/javascripts/app/discussions/new/templates/mobile_edit_step2.html.slim
@@ -1,6 +1,6 @@
 .TopBarLayout
   .TopBarLayout-header
-    md-toolbar.md-whiteframe-z1.md-accent layout="row" layout-align="space-between center"
+    toolbar shadow="enabled" style="accent"
       md-button.md-primary.md-hue-1 md-no-ink="" ui-sref="discussions.edit.step1"
         .IconLeft
         |  back

--- a/app/assets/javascripts/app/discussions/new/templates/mobile_step1.html.slim
+++ b/app/assets/javascripts/app/discussions/new/templates/mobile_step1.html.slim
@@ -1,6 +1,6 @@
 .TopBarLayout
   .TopBarLayout-header
-    md-toolbar.md-whiteframe-z1.md-accent layout="row" layout-align="space-between center"
+    toolbar shadow="enabled" style="accent"
       md-button.md-primary.md-hue-1 md-no-ink="" ui-sref="discussions.index" layout="row" layout-align="center center"
         .IconClose
         | cancel

--- a/app/assets/javascripts/app/discussions/new/templates/mobile_step2.html.slim
+++ b/app/assets/javascripts/app/discussions/new/templates/mobile_step2.html.slim
@@ -1,6 +1,6 @@
 .TopBarLayout
   .TopBarLayout-header
-    md-toolbar.md-whiteframe-z1.md-accent layout="row" layout-align="space-between center"
+    toolbar shadow="enabled" style="accent"
       md-button.md-primary.md-hue-1 md-no-ink="" ui-sref="discussions.new.step1"
         .IconLeft
         |  back

--- a/app/assets/javascripts/app/discussions/show/show.html.slim
+++ b/app/assets/javascripts/app/discussions/show/show.html.slim
@@ -1,12 +1,10 @@
 .TopBarLayout
   .TopBarLayout-header
-    md-toolbar(
-      md-theme="white"
+    toolbar(
+      style="alternative"
       on-scroll=""
       on-scroll-anchor="#js-content"
-      scrolling-class="md-whiteframe-z1"
-      layout="row"
-      layout-align="space-between center")
+      scrolling-class="Toolbar--withShadow")
 
       .Button.Button--flat.Button--left ui-sref="discussions.index"
         .Button-icon

--- a/app/assets/stylesheets/components/_toolbar.css.sass
+++ b/app/assets/stylesheets/components/_toolbar.css.sass
@@ -1,8 +1,27 @@
 .Toolbar
-  .Toolbar-icon
-    width: 30%
+  color: theme-palette(neutral, white)
+  background-color: theme-palette(primary, base)
+  display: flex
+  justify-content: space-between
+  align-items: center
+  transition: box-shadow 0.2s ease-in-out
+  padding: 16px
+  height: $toolbar-height
+
+  [class^="Toolbar-icon"]
     text-align: center
+    width: 30%
 
   .Toolbar-iconLeft
-    width: 30%
     text-align: left
+
+.Toolbar.Toolbar--withShadow
+  box-shadow: 0px 2px 5px 0 rgba(0, 0, 0, 0.26)
+
+.Toolbar.Toolbar--alternative
+  color: theme-palette(primary, dark)
+  background-color: theme-palette(neutral, white)
+
+.Toolbar.Toolbar--accent
+  color: theme-palette(primary, dark)
+  background-color: theme-palette(accent-primary, base)


### PR DESCRIPTION
This pr is a small first step to remove angular material. The directive I created is easier to use and extend.

* Creates custom toolbar component and replaces everywhere.
* Fixes issue when refreshing browser on /discussions/new page.

The reason the default is not having shadow is so we don't have overrides. We add shadows when we need them, instead of overriding to remove them.