### PR TITLE
Add colors to users

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,7 @@ class UsersController < ApplicationController
 
   def update
     user = User.find(params[:id])
-    authorize! :show, user
+    authorize! :update, user
 
     if user.update(user_params)
       render json: user
@@ -20,7 +20,7 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    all_params = params.require(:user).permit(:username, :password, :password_confirmation)
+    all_params = params.require(:user).permit(:username, :password, :password_confirmation, :color)
     all_params.reject do |_, value|
       value.blank?
     end

--- a/app/models/colorize.rb
+++ b/app/models/colorize.rb
@@ -1,0 +1,5 @@
+class Colorize
+  def self.rgb(text)
+    '#' + (text.to_i(36) % 16_777_215).to_s(16).rjust(6, '0')
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,10 @@ class User < ActiveRecord::Base
   has_many :notifications
 
   validates :first_name, :email, presence: true
+  validates :color, format: { with: /#[0-9a-f]{6}/i }, if: :color
+  validates :color, uniqueness: true
+
+  before_create :set_default_color
 
   def display_name
     username.presence || full_name
@@ -23,5 +27,13 @@ class User < ActiveRecord::Base
 
   def full_name
     [first_name, last_name].join(' ').strip
+  end
+
+  def set_default_color
+    set_color_from_display_name if color.blank?
+  end
+
+  def set_color_from_display_name
+    self.color = Colorize.rgb(display_name.gsub(/[^0-9a-zA-Z]+/, ''))
   end
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,3 +1,3 @@
 class UserSerializer < ActiveModel::Serializer
-  attributes :id, :email, :display_name
+  attributes :id, :email, :display_name, :color
 end

--- a/db/migrate/20150622123207_add_color_to_user.rb
+++ b/db/migrate/20150622123207_add_color_to_user.rb
@@ -1,0 +1,5 @@
+class AddColorToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :color, :string
+  end
+end

--- a/db/migrate/20150622173754_add_color_index_to_user.rb
+++ b/db/migrate/20150622173754_add_color_index_to_user.rb
@@ -1,0 +1,5 @@
+class AddColorIndexToUser < ActiveRecord::Migration
+  def change
+    add_index :users, :color, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150408155101) do
+ActiveRecord::Schema.define(version: 20150622173754) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -86,8 +86,10 @@ ActiveRecord::Schema.define(version: 20150408155101) do
     t.string   "last_name",              default: ""
     t.string   "access_token"
     t.string   "username"
+    t.string   "color"
   end
 
+  add_index "users", ["color"], name: "index_users_on_color", unique: true, using: :btree
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -8,6 +8,14 @@ RSpec.describe UsersController, type: :controller do
     sign_in user
   end
 
+  context 'GET /users/:id' do
+    it 'shows a color' do
+      get :show, id: user.id
+
+      expect(response.body).to include 'color'
+    end
+  end
+
   context 'PATCH /users/:id' do
     it 'allows to update username' do
       new_username = 'user1'
@@ -23,6 +31,14 @@ RSpec.describe UsersController, type: :controller do
       patch :update, user: { username: new_username }, id: user.id
 
       expect(user.reload.username).not_to eq new_username
+    end
+
+    it 'allows to update color' do
+      new_color = '#ff0000'
+
+      patch :update, user: { color: new_color }, id: user.id
+
+      expect(user.reload.color).to eq new_color
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,35 +4,64 @@ describe User do
   context '#display_name' do
     context 'username exists' do
       it 'shows username' do
-        expected_username = 'user 1'
-        user = User.new(username: expected_username)
+        user = create(:user)
 
-        display_name = user.display_name
-
-        expect(display_name).to eq expected_username
+        expect(user.display_name).to eq user.username
       end
     end
 
     context 'username does not exist' do
-      it 'does not shows username' do
-        expected_first_name = 'user'
-        expected_last_name = '1'
-        user = User.new(first_name: expected_first_name, last_name: expected_last_name)
+      it 'does not show username' do
+        user = create(:user, username: nil)
+        expected_display_name = "#{user.first_name} #{user.last_name}"
 
-        display_name = user.display_name
-
-        expect(display_name).to eq "#{expected_first_name} #{expected_last_name}"
+        expect(user.display_name).to eq expected_display_name
       end
 
       context 'last name does not exist' do
         it 'shows only the first name' do
-          expected_first_name = 'user'
-          user = User.new(first_name: expected_first_name)
+          user = create(:user,
+            username: nil,
+            last_name: nil)
 
-          display_name = user.display_name
-
-          expect(display_name).to eq expected_first_name
+          expect(user.display_name).to eq user.first_name
         end
+      end
+    end
+  end
+
+  context '#color' do
+    it 'is in RGB format' do
+      user = create(:user)
+
+      expect(user.color).to match(/#[0-9a-f]{6}/i)
+    end
+
+    context 'color exists' do
+      it 'shows color' do
+        user = create(:user, color: '#0000ff')
+
+        expect(user.color).to eq '#0000ff'
+      end
+
+      it 'is valid' do
+        user = create(:user, color: '#0000ff')
+
+        expect(user).to be_valid
+      end
+    end
+
+    context 'color does not exist' do
+      it 'shows some default color' do
+        user = create(:user, color: nil)
+
+        expect(user.color).to match(/#[0-9a-f]{6}/i)
+      end
+
+      it 'is valid' do
+        user = create(:user, color: nil)
+
+        expect(user).to be_valid
       end
     end
   end


### PR DESCRIPTION
This adds a `color` field to `User` model.
The `color` field is a string that must be in RGB format (i.e. `#00ff00`). It's an optional field that, when not present, is computed from the user's display name.